### PR TITLE
Use custom serializers to make test suite less brittle

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
       "json"
     ],
     "snapshotSerializers": [
-      "<rootDir>/tests/coordinate-serializer.js"
+      "<rootDir>/tests/coordinate-serializer.js",
+      "<rootDir>/tests/timestamp-serializer.js"
     ],
     "testRegex": "(\\.(test|spec))\\.(ts|js)$",
     "testPathIgnorePatterns": [

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     ],
     "snapshotSerializers": [
       "<rootDir>/tests/coordinate-serializer.js",
-      "<rootDir>/tests/timestamp-serializer.js"
+      "<rootDir>/tests/timestamp-serializer.js",
+      "<rootDir>/tests/float-serializer.js"
     ],
     "testRegex": "(\\.(test|spec))\\.(ts|js)$",
     "testPathIgnorePatterns": [

--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
       "js",
       "json"
     ],
+    "snapshotSerializers": [
+      "<rootDir>/tests/coordinate-serializer.js"
+    ],
     "testRegex": "(\\.(test|spec))\\.(ts|js)$",
     "testPathIgnorePatterns": [
       "<rootDir>/dist/",

--- a/src/__snapshots__/read-flight.test.ts.snap
+++ b/src/__snapshots__/read-flight.test.ts.snap
@@ -4,7 +4,7 @@ exports[`readFlight() reads "SW_77flqgg1" flight log correctly 1`] = `
 Object {
   "altitude": 44,
   "coordinate": lon 7.0100000 lat 51.0110833,
-  "time": 1500111903000,
+  "time": 2017-07-15T09:45:03.000Z,
   "valid": true,
 }
 `;
@@ -13,7 +13,7 @@ exports[`readFlight() reads "SW_77flqgg1" flight log correctly 2`] = `
 Object {
   "altitude": 1168,
   "coordinate": lon 6.5283500 lat 50.8661500,
-  "time": 1500118283000,
+  "time": 2017-07-15T11:31:23.000Z,
   "valid": true,
 }
 `;
@@ -22,7 +22,7 @@ exports[`readFlight() reads "SW_77flqgg1" flight log correctly 3`] = `
 Object {
   "altitude": 671,
   "coordinate": lon 7.0655833 lat 51.0990833,
-  "time": 1500128791000,
+  "time": 2017-07-15T14:26:31.000Z,
   "valid": true,
 }
 `;

--- a/src/__snapshots__/read-flight.test.ts.snap
+++ b/src/__snapshots__/read-flight.test.ts.snap
@@ -3,10 +3,7 @@
 exports[`readFlight() reads "SW_77flqgg1" flight log correctly 1`] = `
 Object {
   "altitude": 44,
-  "coordinate": Array [
-    7.01,
-    51.01108333333333,
-  ],
+  "coordinate": lon 7.0100000 lat 51.0110833,
   "time": 1500111903000,
   "valid": true,
 }
@@ -15,10 +12,7 @@ Object {
 exports[`readFlight() reads "SW_77flqgg1" flight log correctly 2`] = `
 Object {
   "altitude": 1168,
-  "coordinate": Array [
-    6.52835,
-    50.86615,
-  ],
+  "coordinate": lon 6.5283500 lat 50.8661500,
   "time": 1500118283000,
   "valid": true,
 }
@@ -27,10 +21,7 @@ Object {
 exports[`readFlight() reads "SW_77flqgg1" flight log correctly 3`] = `
 Object {
   "altitude": 671,
-  "coordinate": Array [
-    7.0655833333333335,
-    51.09908333333333,
-  ],
+  "coordinate": lon 7.0655833 lat 51.0990833,
   "time": 1500128791000,
   "valid": true,
 }

--- a/src/task/solver/__snapshots__/racing-task-solver.test.ts.snap
+++ b/src/task/solver/__snapshots__/racing-task-solver.test.ts.snap
@@ -6,28 +6,19 @@ Object {
   "distance": 94373.82458252949,
   "path": Array [
     StartEvent {
-      "point": Array [
-        6.917970423726742,
-        51.12764467984819,
-      ],
+      "point": lon 6.9179704 lat 51.1276447,
       "time": 1500300414931.921,
       "type": "start",
     },
     TurnEvent {
       "num": 1,
-      "point": Array [
-        6.281255521419947,
-        50.98907556181277,
-      ],
+      "point": lon 6.2812555 lat 50.9890756,
       "time": 1500306179779.143,
       "type": "turn",
     },
     TurnEvent {
       "num": 2,
-      "point": Array [
-        6.193755882287799,
-        51.17227647084881,
-      ],
+      "point": lon 6.1937559 lat 51.1722765,
       "time": 1500308464911.7659,
       "type": "turn",
     },
@@ -43,45 +34,30 @@ Object {
   "distance": 136420.85415876907,
   "path": Array [
     StartEvent {
-      "point": Array [
-        6.931349782770249,
-        51.08473062172237,
-      ],
+      "point": lon 6.9313498 lat 51.0847306,
       "time": 1500303056825.019,
       "type": "start",
     },
     TurnEvent {
       "num": 1,
-      "point": Array [
-        6.282918718345648,
-        50.99645952012375,
-      ],
+      "point": lon 6.2829187 lat 50.9964595,
       "time": 1500305066358.2283,
       "type": "turn",
     },
     TurnEvent {
       "num": 2,
-      "point": Array [
-        6.19418395011852,
-        51.17234406494242,
-      ],
+      "point": lon 6.1941840 lat 51.1723441,
       "time": 1500306711548.8186,
       "type": "turn",
     },
     TurnEvent {
       "num": 3,
-      "point": Array [
-        6.607500097039638,
-        50.96949152110721,
-      ],
+      "point": lon 6.6075001 lat 50.9694915,
       "time": 1500308404130.9412,
       "type": "turn",
     },
     FinishEvent {
-      "point": Array [
-        7.008423480016633,
-        51.098512598025316,
-      ],
+      "point": lon 7.0084235 lat 51.0985126,
       "time": 1500309550837.2542,
       "type": "finish",
     },
@@ -97,19 +73,13 @@ Object {
   "distance": 52735.15992428783,
   "path": Array [
     StartEvent {
-      "point": Array [
-        6.914785463652347,
-        51.13786038310547,
-      ],
+      "point": lon 6.9147855 lat 51.1378604,
       "time": 1500301028833.1543,
       "type": "start",
     },
     TurnEvent {
       "num": 1,
-      "point": Array [
-        6.282918718345648,
-        50.99645952012375,
-      ],
+      "point": lon 6.2829187 lat 50.9964595,
       "time": 1500305066358.2283,
       "type": "turn",
     },
@@ -125,45 +95,30 @@ Object {
   "distance": 136420.85415876907,
   "path": Array [
     StartEvent {
-      "point": Array [
-        6.931349782770249,
-        51.08473062172237,
-      ],
+      "point": lon 6.9313498 lat 51.0847306,
       "time": 1500303056825.019,
       "type": "start",
     },
     TurnEvent {
       "num": 1,
-      "point": Array [
-        6.282918718345648,
-        50.99645952012375,
-      ],
+      "point": lon 6.2829187 lat 50.9964595,
       "time": 1500305066358.2283,
       "type": "turn",
     },
     TurnEvent {
       "num": 2,
-      "point": Array [
-        6.19418395011852,
-        51.17234406494242,
-      ],
+      "point": lon 6.1941840 lat 51.1723441,
       "time": 1500306711548.8186,
       "type": "turn",
     },
     TurnEvent {
       "num": 3,
-      "point": Array [
-        6.607500097039638,
-        50.96949152110721,
-      ],
+      "point": lon 6.6075001 lat 50.9694915,
       "time": 1500308404130.9412,
       "type": "turn",
     },
     FinishEvent {
-      "point": Array [
-        7.008423480016633,
-        51.098512598025316,
-      ],
+      "point": lon 7.0084235 lat 51.0985126,
       "time": 1500309550837.2542,
       "type": "finish",
     },

--- a/src/task/solver/__snapshots__/racing-task-solver.test.ts.snap
+++ b/src/task/solver/__snapshots__/racing-task-solver.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`RacingTaskSolver with task "2017-07-17-lev.tsk" can handle outlandings 1`] = `
 Object {
   "completed": false,
-  "distance": 94373.82458252949,
+  "distance": 94373.825,
   "path": Array [
     StartEvent {
       "point": lon 6.9179704 lat 51.1276447,
@@ -31,7 +31,7 @@ Object {
 exports[`RacingTaskSolver with task "2017-07-17-lev.tsk" returns a result 1`] = `
 Object {
   "completed": true,
-  "distance": 136420.85415876907,
+  "distance": 136420.85,
   "path": Array [
     StartEvent {
       "point": lon 6.9313498 lat 51.0847306,
@@ -62,15 +62,15 @@ Object {
       "type": "finish",
     },
   ],
-  "speed": 75.62583148774199,
-  "time": 6494.0122351074215,
+  "speed": 75.625831,
+  "time": 6494.0122,
 }
 `;
 
 exports[`RacingTaskSolver with task "2017-07-17-lev.tsk" returns an intermediate result 1`] = `
 Object {
   "completed": false,
-  "distance": 52735.15992428783,
+  "distance": 52735.160,
   "path": Array [
     StartEvent {
       "point": lon 6.9147855 lat 51.1378604,
@@ -92,7 +92,7 @@ Object {
 exports[`RacingTaskSolver with task "2017-07-17-lev.tsk" returns an intermediate result 2`] = `
 Object {
   "completed": true,
-  "distance": 136420.85415876907,
+  "distance": 136420.85,
   "path": Array [
     StartEvent {
       "point": lon 6.9313498 lat 51.0847306,
@@ -123,7 +123,7 @@ Object {
       "type": "finish",
     },
   ],
-  "speed": 75.62583148774199,
-  "time": 6494.0122351074215,
+  "speed": 75.625831,
+  "time": 6494.0122,
 }
 `;

--- a/src/task/solver/__snapshots__/racing-task-solver.test.ts.snap
+++ b/src/task/solver/__snapshots__/racing-task-solver.test.ts.snap
@@ -7,19 +7,19 @@ Object {
   "path": Array [
     StartEvent {
       "point": lon 6.9179704 lat 51.1276447,
-      "time": 1500300414931.921,
+      "time": 2017-07-17T14:06:54.931Z,
       "type": "start",
     },
     TurnEvent {
       "num": 1,
       "point": lon 6.2812555 lat 50.9890756,
-      "time": 1500306179779.143,
+      "time": 2017-07-17T15:42:59.779Z,
       "type": "turn",
     },
     TurnEvent {
       "num": 2,
       "point": lon 6.1937559 lat 51.1722765,
-      "time": 1500308464911.7659,
+      "time": 2017-07-17T16:21:04.911Z,
       "type": "turn",
     },
   ],
@@ -35,30 +35,30 @@ Object {
   "path": Array [
     StartEvent {
       "point": lon 6.9313498 lat 51.0847306,
-      "time": 1500303056825.019,
+      "time": 2017-07-17T14:50:56.825Z,
       "type": "start",
     },
     TurnEvent {
       "num": 1,
       "point": lon 6.2829187 lat 50.9964595,
-      "time": 1500305066358.2283,
+      "time": 2017-07-17T15:24:26.358Z,
       "type": "turn",
     },
     TurnEvent {
       "num": 2,
       "point": lon 6.1941840 lat 51.1723441,
-      "time": 1500306711548.8186,
+      "time": 2017-07-17T15:51:51.548Z,
       "type": "turn",
     },
     TurnEvent {
       "num": 3,
       "point": lon 6.6075001 lat 50.9694915,
-      "time": 1500308404130.9412,
+      "time": 2017-07-17T16:20:04.130Z,
       "type": "turn",
     },
     FinishEvent {
       "point": lon 7.0084235 lat 51.0985126,
-      "time": 1500309550837.2542,
+      "time": 2017-07-17T16:39:10.837Z,
       "type": "finish",
     },
   ],
@@ -74,13 +74,13 @@ Object {
   "path": Array [
     StartEvent {
       "point": lon 6.9147855 lat 51.1378604,
-      "time": 1500301028833.1543,
+      "time": 2017-07-17T14:17:08.833Z,
       "type": "start",
     },
     TurnEvent {
       "num": 1,
       "point": lon 6.2829187 lat 50.9964595,
-      "time": 1500305066358.2283,
+      "time": 2017-07-17T15:24:26.358Z,
       "type": "turn",
     },
   ],
@@ -96,30 +96,30 @@ Object {
   "path": Array [
     StartEvent {
       "point": lon 6.9313498 lat 51.0847306,
-      "time": 1500303056825.019,
+      "time": 2017-07-17T14:50:56.825Z,
       "type": "start",
     },
     TurnEvent {
       "num": 1,
       "point": lon 6.2829187 lat 50.9964595,
-      "time": 1500305066358.2283,
+      "time": 2017-07-17T15:24:26.358Z,
       "type": "turn",
     },
     TurnEvent {
       "num": 2,
       "point": lon 6.1941840 lat 51.1723441,
-      "time": 1500306711548.8186,
+      "time": 2017-07-17T15:51:51.548Z,
       "type": "turn",
     },
     TurnEvent {
       "num": 3,
       "point": lon 6.6075001 lat 50.9694915,
-      "time": 1500308404130.9412,
+      "time": 2017-07-17T16:20:04.130Z,
       "type": "turn",
     },
     FinishEvent {
       "point": lon 7.0084235 lat 51.0985126,
-      "time": 1500309550837.2542,
+      "time": 2017-07-17T16:39:10.837Z,
       "type": "finish",
     },
   ],

--- a/src/xcsoar/__snapshots__/index.test.ts.snap
+++ b/src/xcsoar/__snapshots__/index.test.ts.snap
@@ -13,7 +13,7 @@ Object {
       "waypoint": Object {
         "altitude": 86,
         "location": Object {
-          "latitude": 51.1413833,
+          "latitude": 51.141383,
           "longitude": 6.9852833,
         },
         "name": "Langenfeld-Wiescheid",
@@ -28,8 +28,8 @@ Object {
       "waypoint": Object {
         "altitude": 190,
         "location": Object {
-          "latitude": 50.8241667,
-          "longitude": 6.18695,
+          "latitude": 50.824167,
+          "longitude": 6.1869500,
         },
         "name": "Aachen Merzbrück",
       },
@@ -43,8 +43,8 @@ Object {
       "waypoint": Object {
         "altitude": 205,
         "location": Object {
-          "latitude": 50.5597167,
-          "longitude": 7.1375,
+          "latitude": 50.559717,
+          "longitude": 7.1375000,
         },
         "name": "Bad Neuenahr",
       },
@@ -58,7 +58,7 @@ Object {
       "waypoint": Object {
         "altitude": 7,
         "location": Object {
-          "latitude": 50.8888833,
+          "latitude": 50.888883,
           "longitude": 6.4916667,
         },
         "name": "058Hambach Süd",
@@ -73,8 +73,8 @@ Object {
       "waypoint": Object {
         "altitude": 200,
         "location": Object {
-          "latitude": 51.17695,
-          "longitude": 7.2,
+          "latitude": 51.176950,
+          "longitude": 7.2000000,
         },
         "name": "110Remscheid Bhf",
       },
@@ -88,8 +88,8 @@ Object {
       "waypoint": Object {
         "altitude": 130,
         "location": Object {
-          "latitude": 51.0977833,
-          "longitude": 7.03695,
+          "latitude": 51.097783,
+          "longitude": 7.0369500,
         },
         "name": "002Zielkreis",
       },
@@ -112,7 +112,7 @@ Object {
       "waypoint": Object {
         "altitude": 50,
         "location": Object {
-          "latitude": 51.08195,
+          "latitude": 51.081950,
           "longitude": 6.9322167,
         },
         "name": "095Monheim AB Dreieck",
@@ -126,7 +126,7 @@ Object {
       "waypoint": Object {
         "altitude": 100,
         "location": Object {
-          "latitude": 50.9991667,
+          "latitude": 50.999167,
           "longitude": 6.2772167,
         },
         "name": "084Linnich Kontrollpunkt",
@@ -140,7 +140,7 @@ Object {
       "waypoint": Object {
         "altitude": 86,
         "location": Object {
-          "latitude": 51.1766667,
+          "latitude": 51.176667,
           "longitude": 6.1922167,
         },
         "name": "113Ritzeroder Duenen",
@@ -154,7 +154,7 @@ Object {
       "waypoint": Object {
         "altitude": 70,
         "location": Object {
-          "latitude": 50.965,
+          "latitude": 50.965000,
           "longitude": 6.6077833,
         },
         "name": "021Bergheim",
@@ -169,8 +169,8 @@ Object {
       "waypoint": Object {
         "altitude": 130,
         "location": Object {
-          "latitude": 51.0977833,
-          "longitude": 7.03695,
+          "latitude": 51.097783,
+          "longitude": 7.0369500,
         },
         "name": "002Zielkreis",
       },

--- a/tests/coordinate-serializer.js
+++ b/tests/coordinate-serializer.js
@@ -1,0 +1,9 @@
+module.exports = {
+  test(val) {
+    return val && val.length === 2 && typeof val[0] === 'number' && typeof val[1] === 'number';
+  },
+
+  print(val) {
+    return `lon ${val[0].toFixed(7)} lat ${val[1].toFixed(7)}`;
+  },
+};

--- a/tests/float-serializer.js
+++ b/tests/float-serializer.js
@@ -1,0 +1,9 @@
+module.exports = {
+  test(val) {
+    return typeof val === 'number' && !Number.isInteger(val);
+  },
+
+  print(val) {
+    return val.toPrecision(8);
+  },
+};

--- a/tests/timestamp-serializer.js
+++ b/tests/timestamp-serializer.js
@@ -1,0 +1,10 @@
+module.exports = {
+  test(val) {
+    return typeof val === 'number' && val > Date.parse('1980-01-01') && val < Date.parse('2050-01-01');
+  },
+
+  print(val) {
+    let date = new Date(val);
+    return date.toISOString();
+  },
+};


### PR DESCRIPTION
This PR introduces two custom snapshot serializers to the test suite that limit the precision of coordinates and timestamps to meaningful values.