### PR TITLE
Drop Node 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-- '6'
+- '8'
+- '10'
 
 script:
   - yarn build

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "ws": "^5.2.0"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "alwaysStrict": true,
     "declaration": true,
-    "lib": ["ES6"],
+    "lib": ["ES2017"],
     "module": "commonjs",
     "moduleResolution": "node",
     "newLine": "LF",


### PR DESCRIPTION
No need to be as conservative as Ember CLI here :)

This is not labeled as a breaking change because we haven't actually released anything yet.