### PR TITLE
 examples/calc-ranking: Simplify arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ library is currently capable of. It is recommended to run them using
 [ts-node](https://github.com/TypeStrong/ts-node). For example:
 
 ```bash
-ts-node examples/calc-ranking.ts fixtures/2017-07-17-lev.tsk fixtures/2017-07-17-lev
+ts-node examples/calc-ranking.ts fixtures/2017-07-17-lev
 ```
 
 

--- a/examples/calc-ranking.ts
+++ b/examples/calc-ranking.ts
@@ -123,7 +123,7 @@ function readCSV(path: string) {
   let handicaps = Object.create(null);
   lines.map(line => line.trim().split(',')).forEach(([id, _, cn, type, handicap]) => {
     if (id) {
-      handicaps[cn] = parseInt(handicap, 10);
+      handicaps[cn] = handicap ? parseInt(handicap, 10) : 100;
     }
   });
   return handicaps;

--- a/examples/calc-ranking.ts
+++ b/examples/calc-ranking.ts
@@ -1,6 +1,5 @@
 import fs = require('fs');
 
-import {analyzeFlight} from '../src/analyze-flight';
 import {formatTime} from '../src/format-result';
 import {readFlight} from '../src/read-flight';
 import {readTask} from '../src/read-task';

--- a/examples/calc-ranking.ts
+++ b/examples/calc-ranking.ts
@@ -7,36 +7,35 @@ import RacingTaskSolver from '../src/task/solver/racing-task-solver';
 
 const logUpdate = require('log-update');
 
-if (process.argv.length < 4) {
-  console.log('Usage: ts-node examples/calc-ranking.ts TASK_PATH IGC_FOLDER');
+if (process.argv.length < 3) {
+  console.log('Usage: ts-node examples/calc-ranking.ts FOLDER');
   process.exit(1);
 }
 
-let taskPath = process.argv[2];
-let task = readTask(taskPath);
+let folder = process.argv[2];
+
+let task = readTask(`${folder}/task.tsk`);
 
 if (task.options.isAAT) {
   console.log('AAT tasks are not supported yet');
   process.exit(1);
 }
 
-let handicaps = readCSV(`${__dirname}/../fixtures/2017-lev.csv`);
-
-let flightsPath = process.argv[3];
+let handicaps = readCSV(`${folder}/filter.csv`);
 
 let callsigns: string[] = [];
 let flights: any = {};
 let solvers: any = {};
 let indexes: any = {};
 
-fs.readdirSync(flightsPath)
+fs.readdirSync(folder)
   .filter(filename => (/\.igc$/i).test(filename))
   .forEach(filename => {
     let callsign = filename.match(/^(.{1,3})_/)![1];
 
     callsigns.push(callsign.toUpperCase());
 
-    flights[callsign.toUpperCase()] = readFlight(`${flightsPath}/${filename}`);
+    flights[callsign.toUpperCase()] = readFlight(`${folder}/${filename}`);
     solvers[callsign.toUpperCase()] = new RacingTaskSolver(task);
     indexes[callsign.toUpperCase()] = 0;
   });


### PR DESCRIPTION
Instead of passing a task file and a IGC folder name to the example script we now only require the folder name and assume that it contains a `filter.csv` and `task.tsk` file. The example snippet in the README is updated accordingly.