### PR TITLE
Update `cli-table2` to `cli-table3`

### DIFF
--- a/examples/calc-ranking.ts
+++ b/examples/calc-ranking.ts
@@ -1,8 +1,5 @@
 import fs = require('fs');
 
-import Table = require('cli-table2');
-import {HorizontalTable} from 'cli-table2';
-
 import {formatDuration, formatTime} from '../src/format-result';
 import {readFlight} from '../src/read-flight';
 import {readTask} from '../src/read-task';
@@ -18,6 +15,7 @@ import {
 import RacingTaskSolver from '../src/task/solver/racing-task-solver';
 import {readFromFile} from '../src/utils/filter';
 
+const Table = require('cli-table3');
 const logUpdate = require('log-update');
 
 if (process.argv.length < 3) {
@@ -128,7 +126,7 @@ function tick() {
     colAligns: ['right', 'left', 'left', 'left', 'right', 'right', 'right', 'right', 'right'],
     colWidths: [null, null, null, null, 10, 10, 10, 13, 7],
     chars: {'mid': '', 'left-mid': '', 'mid-mid': '', 'right-mid': ''},
-  }) as HorizontalTable;
+  });
 
   fullResults.forEach((result: any, i) => {
     let { filterRow } = result;

--- a/examples/live-scoring.ts
+++ b/examples/live-scoring.ts
@@ -1,7 +1,5 @@
 import {BBox} from 'cheap-ruler';
-import {HorizontalTable} from 'cli-table2';
 
-import Table = require('cli-table2');
 import {formatDuration, formatTime} from '../src/format-result';
 import Point from '../src/geo/point';
 import GliderTrackerClient from '../src/glidertracker/client';
@@ -18,6 +16,7 @@ import {
 import RacingTaskSolver from '../src/task/solver/racing-task-solver';
 import {readFromFile} from '../src/utils/filter';
 
+const Table = require('cli-table3');
 const logUpdate = require('log-update');
 
 let now = new Date();
@@ -154,7 +153,7 @@ setInterval(() => {
     colAligns: ['right', 'left', 'left', 'left', 'right', 'right', 'right', 'right', 'right'],
     colWidths: [null, null, null, null, 10, 10, 10, 13, 7],
     chars: {'mid': '', 'left-mid': '', 'mid-mid': '', 'right-mid': ''},
-  }) as HorizontalTable;
+  });
 
   fullResults.forEach((result: any, i) => {
     let { filterRow } = result;

--- a/package.json
+++ b/package.json
@@ -31,12 +31,11 @@
     "xml-js": "^1.6.4"
   },
   "devDependencies": {
-    "@types/cli-table2": "^0.2.1",
     "@types/d3-dsv": "^1.0.33",
     "@types/geojson": "^7946.0.3",
     "@types/jest": "^23.0.0",
     "@types/node": "^6.0.83",
-    "cli-table2": "^0.2.0",
+    "cli-table3": "^0.5.0",
     "d3-dsv": "^1.0.8",
     "jest": "^23.1.0",
     "log-update": "^2.3.0",

--- a/tests/generators.ts
+++ b/tests/generators.ts
@@ -1,8 +1,5 @@
 import fs = require('fs');
 
-import Table = require('cli-table2');
-import {HorizontalTable} from 'cli-table2';
-
 import {formatDuration, formatTime} from '../src/format-result';
 import {readFlight} from '../src/read-flight';
 import {readTask} from '../src/read-task';
@@ -17,6 +14,8 @@ import {
 } from '../src/scoring';
 import RacingTaskSolver from '../src/task/solver/racing-task-solver';
 import {readFromFile} from '../src/utils/filter';
+
+const Table = require('cli-table3');
 
 const FIXTURES_PATH = `${__dirname}/../fixtures`;
 
@@ -86,7 +85,7 @@ export function generateRacingTest(fixtureName: string, until: string | null = n
         colAligns: ['right', 'left', 'left', 'left', 'right', 'right', 'right', 'right', 'right'],
         chars: {'mid': '', 'left-mid': '', 'mid-mid': '', 'right-mid': ''},
         style: { head: [], border: [] },
-      }) as HorizontalTable;
+      });
 
       fullResults.forEach((result: any, i) => {
         let { pilot } = result;

--- a/yarn.lock
+++ b/yarn.lock
@@ -137,10 +137,6 @@
     "@turf/invariant" "6.x"
     martinez-polygon-clipping "*"
 
-"@types/cli-table2@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@types/cli-table2/-/cli-table2-0.2.1.tgz#08faf5ce07115b0fd5c73c3dca9e8de3e2cf1d8e"
-
 "@types/d3-dsv@^1.0.33":
   version "1.0.33"
   resolved "https://registry.yarnpkg.com/@types/d3-dsv/-/d3-dsv-1.0.33.tgz#18de1867927f7ec898671aef82f730f16d4c7fcb"
@@ -823,12 +819,12 @@ cli-cursor@^2.0.0:
   dependencies:
     restore-cursor "^2.0.0"
 
-cli-table2@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/cli-table2/-/cli-table2-0.2.0.tgz#2d1ef7f218a0e786e214540562d4bd177fe32d97"
+cli-table3@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.5.0.tgz#adb2f025715f4466e67629783c8d73e9030eb4bd"
   dependencies:
-    lodash "^3.10.1"
-    string-width "^1.0.1"
+    object-assign "^4.1.0"
+    string-width "^2.1.1"
   optionalDependencies:
     colors "^1.1.2"
 
@@ -2485,10 +2481,6 @@ locate-path@^2.0.0:
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
-
-lodash@^3.10.1:
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
 lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.4:
   version "4.17.10"


### PR DESCRIPTION
This PR updates the `cli-table2` dependency to `cli-table3`, which fixes one of the `npm audit` warnings :)

`cli-table2` (like `cli-table` itself) is no longer maintained. In jamestalmage/cli-table2#43 a couple of people have offered to take over maintenance but the current maintainer did not respond so as a result the project was forked to https://github.com/cli-table/cli-table3.
