### PR TITLE
Fix/Improve `live-scoring` example

### DIFF
--- a/examples/live-scoring.ts
+++ b/examples/live-scoring.ts
@@ -20,159 +20,163 @@ import {readFromFile} from '../src/utils/filter';
 const Table = require('cli-table3');
 const logUpdate = require('log-update');
 
-let now = new Date();
-let day = now.getDate();
-let month = now.getMonth() + 1;
-let date = `${now.getFullYear()}-${month < 10 ? `0${month}` : month}-${day < 10 ? `0${day}` : day}`;
+function run(argv: string[]) {
+  let now = new Date();
+  let day = now.getDate();
+  let month = now.getMonth() + 1;
+  let date = `${now.getFullYear()}-${month < 10 ? `0${month}` : month}-${day < 10 ? `0${day}` : day}`;
 
-let from = Date.parse(`${date}T00:00:00`);
-let to = Date.now();
+  let from = Date.parse(`${date}T00:00:00`);
+  let to = Date.now();
 
-if (process.argv.length < 4) {
-  console.log('Usage: ts-node examples/live-scoring.ts TASK_PATH CSV_PATH');
-  process.exit(1);
-}
-
-let taskPath = process.argv[2];
-let task = readTask(taskPath);
-
-let filterRows = readFromFile(process.argv[3]);
-
-let fixesById = new Map<string, Fix[]>();
-for (let filterRow of filterRows) {
-  fixesById.set(filterRow.ognID, []);
-}
-
-let client = new GliderTrackerClient({ WebSocket: require('ws') });
-
-function connect() {
-  client.connect().then(() => {
-    client.setView(task.bbox as BBox);
-
-    for (let filterRow of filterRows) {
-      client.requestTrack(filterRow.ognID, from, to);
-    }
-  });
-}
-
-connect();
-
-client.onClose = function() {
-  console.log('Reconnecting...');
-  connect();
-};
-
-client.onTrack = function(id, _fixes) {
-  let fixes = fixesById.get(id);
-  if (fixes) {
-    fixes.push(..._fixes.map(fix => ({
-      time: fix.time,
-      coordinate: [fix.lon, fix.lat] as Point,
-      valid: true,
-      altitude: fix.alt / 10 * 3,
-    })));
+  if (argv.length < 4) {
+    console.log('Usage: ts-node examples/live-scoring.ts TASK_PATH CSV_PATH');
+    process.exit(1);
   }
-};
 
-client.onRecord = function(record) {
-  if (!record.data.comment)
-    return;
+  let taskPath = argv[2];
+  let task = readTask(taskPath);
 
-  let match = record.data.comment.match(/id([0-9a-f]{8})/i);
-  if (!match)
-    return;
+  let filterRows = readFromFile(argv[3]);
 
-  let id = match[1];
-  let flarmMapping = filterRows.find(row => row.ognID === id);
-  if (!flarmMapping)
-    return;
+  let fixesById = new Map<string, Fix[]>();
+  for (let filterRow of filterRows) {
+    fixesById.set(filterRow.ognID, []);
+  }
 
-  let fixes = fixesById.get(id);
+  let client = new GliderTrackerClient({WebSocket: require('ws')});
 
-  let data = record.data;
-  if (fixes && data) {
-    fixes.push({
-      time: Date.parse(data.timestamp),
-      coordinate: [parseFloat(data.longitude), parseFloat(data.latitude)],
-      valid: true,
-      altitude: data.altitude,
+  function connect() {
+    client.connect().then(() => {
+      client.setView(task.bbox as BBox);
+
+      for (let filterRow of filterRows) {
+        client.requestTrack(filterRow.ognID, from, to);
+      }
     });
   }
-};
 
-let initialDayFactors: InitialDayFactors = {
-  // Task Distance [km]
-  // Dt: task.distance / 1000,
+  connect();
 
-  // Minimum Task Time [s]
-  // Td: task.options.aatMinTime || 0,
+  client.onClose = function() {
+    console.log('Reconnecting...');
+    connect();
+  };
 
-  // Lowest Handicap (H) of all competitors
-  Ho: Math.min(...filterRows.map(it => it.handicap)) / 100,
+  client.onTrack = function(id, _fixes) {
+    let fixes = fixesById.get(id);
+    if (fixes) {
+      fixes.push(..._fixes.map(fix => ({
+        time: fix.time,
+        coordinate: [fix.lon, fix.lat] as Point,
+        valid: true,
+        altitude: fix.alt / 10 * 3,
+      })));
+    }
+  };
 
-  // Minimum Handicapped Distance to validate the Day [km]
-  Dm: 100,
-};
+  client.onRecord = function(record) {
+    if (!record.data.comment)
+      return;
 
-setInterval(() => {
-  let results: InitialDayResult[] = filterRows.map(filterRow => {
-    let fixes = fixesById.get(filterRow.ognID)!;
+    let match = record.data.comment.match(/id([0-9a-f]{8})/i);
+    if (!match)
+      return;
 
-    let solver = task.options.isAAT
-      ? new AreaTaskSolver(task)
-      : new RacingTaskSolver(task);
+    let id = match[1];
+    let flarmMapping = filterRows.find(row => row.ognID === id);
+    if (!flarmMapping)
+      return;
 
-    solver.consume(fixes);
+    let fixes = fixesById.get(id);
 
-    let lastFix = fixes[fixes.length - 1];
-    let altitude = lastFix ? lastFix.altitude : null;
+    let data = record.data;
+    if (fixes && data) {
+      fixes.push({
+        time: Date.parse(data.timestamp),
+        coordinate: [parseFloat(data.longitude), parseFloat(data.latitude)],
+        valid: true,
+        altitude: data.altitude,
+      });
+    }
+  };
 
-    let result = solver.result;
+  let initialDayFactors: InitialDayFactors = {
+    // Task Distance [km]
+    // Dt: task.distance / 1000,
 
-    let landed = false; // TODO
+    // Minimum Task Time [s]
+    // Td: task.options.aatMinTime || 0,
 
-    let start = result.path[0];
-    let startTimestamp = start && result.distance ? start.time : null;
+    // Lowest Handicap (H) of all competitors
+    Ho: Math.min(...filterRows.map(it => it.handicap)) / 100,
 
-    // Competitor’s Handicap, if handicapping is being used; otherwise H=1
-    let H = filterRow.handicap / 100;
+    // Minimum Handicapped Distance to validate the Day [km]
+    Dm: 100,
+  };
 
-    let dayResult = (landed || result.completed || task.options.isAAT)
-      ? createInitialDayResult(result, initialDayFactors, H)
-      : createIntermediateDayResult(result, initialDayFactors, H, task, Date.now());
+  setInterval(() => {
+    let results: InitialDayResult[] = filterRows.map(filterRow => {
+      let fixes = fixesById.get(filterRow.ognID)!;
 
-    return { ...dayResult, landed, filterRow, startTimestamp, altitude };
-  });
+      let solver = task.options.isAAT
+        ? new AreaTaskSolver(task)
+        : new RacingTaskSolver(task);
 
-  let dayFactors = calculateDayFactors(results, initialDayFactors);
+      solver.consume(fixes);
 
-  let fullResults = results
-    .map(result => calculateDayResult(result, dayFactors))
-    .sort(compareDayResults);
+      let lastFix = fixes[fixes.length - 1];
+      let altitude = lastFix ? lastFix.altitude : null;
 
-  let table = new Table({
-    head: ['#', 'WBK', 'Name', 'Plane', 'Start', 'Time', 'Dist', 'Speed', 'Score', 'Alt.'],
-    colAligns: ['right', 'left', 'left', 'left', 'right', 'right', 'right', 'right', 'right', 'right'],
-    colWidths: [null, null, null, null, 10, 10, 10, 13, 7, 8],
-    chars: {'mid': '', 'left-mid': '', 'mid-mid': '', 'right-mid': ''},
-  });
+      let result = solver.result;
 
-  fullResults.forEach((result: any, i) => {
-    let { filterRow } = result;
+      let landed = false; // TODO
 
-    table.push([
-      `${result.landed || result._completed ? ' ' : '!'} ${(i + 1)}`,
-      filterRow.callsign,
-      filterRow.pilot,
-      filterRow.type,
-      result.startTimestamp ? formatTime(result.startTimestamp) : '',
-      result._T ? formatDuration(result._T) : '',
-      result._D ? `${result._D.toFixed(1)} km` : '',
-      result._V ? `${result._V.toFixed(2)} km/h` : '',
-      result.S,
-      result.altitude !== null ? `${result.altitude} m` : '',
-    ]);
-  });
+      let start = result.path[0];
+      let startTimestamp = start && result.distance ? start.time : null;
 
-  logUpdate(`${new Date().toISOString()}\n\n${table.toString()}`);
-}, 100);
+      // Competitor’s Handicap, if handicapping is being used; otherwise H=1
+      let H = filterRow.handicap / 100;
+
+      let dayResult = (landed || result.completed || task.options.isAAT)
+        ? createInitialDayResult(result, initialDayFactors, H)
+        : createIntermediateDayResult(result, initialDayFactors, H, task, Date.now());
+
+      return {...dayResult, landed, filterRow, startTimestamp, altitude};
+    });
+
+    let dayFactors = calculateDayFactors(results, initialDayFactors);
+
+    let fullResults = results
+      .map(result => calculateDayResult(result, dayFactors))
+      .sort(compareDayResults);
+
+    let table = new Table({
+      head: ['#', 'WBK', 'Name', 'Plane', 'Start', 'Time', 'Dist', 'Speed', 'Score', 'Alt.'],
+      colAligns: ['right', 'left', 'left', 'left', 'right', 'right', 'right', 'right', 'right', 'right'],
+      colWidths: [null, null, null, null, 10, 10, 10, 13, 7, 8],
+      chars: {'mid': '', 'left-mid': '', 'mid-mid': '', 'right-mid': ''},
+    });
+
+    fullResults.forEach((result: any, i) => {
+      let {filterRow} = result;
+
+      table.push([
+        `${result.landed || result._completed ? ' ' : '!'} ${(i + 1)}`,
+        filterRow.callsign,
+        filterRow.pilot,
+        filterRow.type,
+        result.startTimestamp ? formatTime(result.startTimestamp) : '',
+        result._T ? formatDuration(result._T) : '',
+        result._D ? `${result._D.toFixed(1)} km` : '',
+        result._V ? `${result._V.toFixed(2)} km/h` : '',
+        result.S,
+        result.altitude !== null ? `${result.altitude} m` : '',
+      ]);
+    });
+
+    logUpdate(`${new Date().toISOString()}\n\n${table.toString()}`);
+  }, 100);
+}
+
+run(process.argv);

--- a/examples/live-scoring.ts
+++ b/examples/live-scoring.ts
@@ -175,7 +175,7 @@ async function run(argv: string[]) {
 
       let dayResult = (landed || result.completed || task.options.isAAT)
         ? createInitialDayResult(result, initialDayFactors, H)
-        : createIntermediateDayResult(result, initialDayFactors, H, task, Date.now());
+        : createIntermediateDayResult(result, initialDayFactors, H, task, Date.now() / 1000);
 
       return {...dayResult, landed, filterRow, startTimestamp, altitude};
     });

--- a/examples/live-scoring.ts
+++ b/examples/live-scoring.ts
@@ -206,7 +206,7 @@ async function run(argv: string[]) {
         result._D ? `${result._D.toFixed(1)} km` : '',
         result._V ? `${result._V.toFixed(2)} km/h` : '',
         result.S,
-        result.altitude !== null ? `${result.altitude} m` : '',
+        result.altitude !== null ? `${Math.round(result.altitude)} m` : '',
       ]);
     });
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/node": "^6.0.83",
     "cli-table3": "^0.5.0",
     "d3-dsv": "^1.0.8",
+    "fetch-ponyfill": "^6.0.2",
     "jest": "^23.2.0",
     "log-update": "^2.3.0",
     "opn": "^5.3.0",

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -28,7 +28,7 @@ export function readHandicapsFromFile(path: string): { [key: string]: number } {
   return handicaps;
 }
 
-interface Competitor {
+export interface Competitor {
   ognID: string;
   registration: string;
   callsign: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1153,6 +1153,12 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
+fetch-ponyfill@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/fetch-ponyfill/-/fetch-ponyfill-6.0.2.tgz#bc2d92afd0140e39518beccd2fd0682ab4491cb6"
+  dependencies:
+    node-fetch "~2.1.0"
+
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
@@ -2466,6 +2472,10 @@ needle@^2.2.0:
     debug "^2.1.2"
     iconv-lite "^0.4.4"
     sax "^1.2.4"
+
+node-fetch@~2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
This PR allows us to call the example e.g. like this:

```
ts-node examples/live-scoring.ts "http://glidertracker.org/#tsk=https://gist.github.com/hsteinhaus/4369987643f0081d49c4458baa8c1422/raw/task&lst=https://gist.github.com/hsteinhaus/4369987643f0081d49c4458baa8c1422/raw/filter"
```

The PR also fixes the broken intermediate times and altitude display.

/cc @dspreitz