### PR TITLE
examples/viewGeoJSON: Expand map to full window height

### DIFF
--- a/examples/utils/view-geojson.ts
+++ b/examples/utils/view-geojson.ts
@@ -7,7 +7,7 @@ export function viewGeoJSON(json: any) {
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.1.0/dist/leaflet.css"/>
   <style>
   body { margin: 0; }
-  #mapid { height: 180px; }
+  #mapid { height: 100%; }
   </style>
 </head>
 <body id="map">


### PR DESCRIPTION
This change fixes the scale and legend to be displayed at the bottom
instead of a fixed distance of 180px from the top window border,
floating above the map; as well as enabling mouse gestures all
over the map.