### PR TITLE
AAT min time handling

### DIFF
--- a/examples/calc-ranking.ts
+++ b/examples/calc-ranking.ts
@@ -125,7 +125,7 @@ function tick() {
   let table = new Table({
     head: ['#', 'WBK', 'Name', 'Plane', 'Start', 'Time', 'Dist', 'Speed', 'Score', 'Alt.'],
     colAligns: ['right', 'left', 'left', 'left', 'right', 'right', 'right', 'right', 'right', 'right'],
-    colWidths: [null, null, null, null, 10, 10, 10, 13, 7, 8],
+    colWidths: [null, null, null, null, 10, 12, 10, 13, 7, 8],
     chars: {'mid': '', 'left-mid': '', 'mid-mid': '', 'right-mid': ''},
   });
 
@@ -138,7 +138,8 @@ function tick() {
       filterRow.pilot,
       filterRow.type,
       result.startTimestamp ? formatTime(result.startTimestamp) : '',
-      result._T ? formatDuration(result._T) : '',
+      `${!result.landed || !result.completed || result.aat_min_time_exceeded ? ' ' : '*' } ` +
+      `${result.T ? formatDuration(result.T) : ''}`,
       result._D ? `${result._D.toFixed(1)} km` : '',
       result._V ? `${result._V.toFixed(2)} km/h` : '',
       result.S,

--- a/examples/calc-ranking.ts
+++ b/examples/calc-ranking.ts
@@ -141,7 +141,7 @@ function tick() {
       `${!result.landed || !result.completed || result.aat_min_time_exceeded ? ' ' : '*' } ` +
       `${result.T ? formatDuration(result.T) : ''}`,
       result._D ? `${result._D.toFixed(1)} km` : '',
-      result._V ? `${result._V.toFixed(2)} km/h` : '',
+      result.V ? `${result.V.toFixed(2)} km/h` : '',
       result.S,
       result.altitude !== null ? `${result.altitude} m` : '',
     ]);

--- a/src/scoring.ts
+++ b/src/scoring.ts
@@ -61,9 +61,11 @@ export function createInitialDayResult(result: any, dayFactors: InitialDayFactor
   // Finisher’s Display Time [s]
   T = _T = result.time;
 
-  // Finisher’s Marking Speed. (V = D / T)
   // Finisher’s Display Speed.
-  V = _V = completed ? D / (T / 3600) : 0;
+  _V = completed ? D / (T / 3600) : 0;
+
+  // Finisher’s Marking Speed.
+  V = completed ? result.speed : 0;
 
   // Competitor’s Handicapped Distance. (Dh = D x Ho / H) [km]
   let Dh = D * (Ho / H) || 0;

--- a/src/scoring.ts
+++ b/src/scoring.ts
@@ -71,7 +71,9 @@ export function createInitialDayResult(result: any, dayFactors: InitialDayFactor
   // Finisher’s Handicapped Speed. (Vh = D / T x Ho / H)
   let Vh = V * (Ho / H) || 0;
 
-  return { completed, _completed, D, _D, H, Dh, T, _T, V, _V, Vh };
+  let aat_min_time_exceeded = result.aat_min_time_exceeded;
+
+  return { aat_min_time_exceeded, completed, _completed, D, _D, H, Dh, T, _T, V, _V, Vh };
 }
 
 export function createIntermediateDayResult(
@@ -110,7 +112,9 @@ export function createIntermediateDayResult(
   // Finisher’s Handicapped Speed. (Vh = D / T x Ho / H)
   let Vh = V * (Ho / H);
 
-  return { completed, _completed, D, _D, H, Dh, T, _T, V, _V, Vh };
+  let aat_min_time_exceeded = result.aat_min_time_exceeded;
+
+  return { aat_min_time_exceeded, completed, _completed, D, _D, H, Dh, T, _T, V, _V, Vh };
 }
 
 export function calculateDayResult(result: InitialDayResult, dayFactors: DayFactors): DayResult {
@@ -196,6 +200,7 @@ export interface DayFactors extends InitialDayFactors {
 }
 
 export interface InitialDayResult {
+  aat_min_time_exceeded: boolean;
   completed: boolean;
   _completed: boolean;
 

--- a/src/task/solver/__snapshots__/area-task-solver.test.ts.snap
+++ b/src/task/solver/__snapshots__/area-task-solver.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`AreaTaskSolver 2017-07-15-lev - 1 final result 1`] = `
 Object {
+  "aat_min_time_exceeded": false,
   "completed": true,
   "distance": 251207.33,
   "path": Array [
@@ -49,6 +50,7 @@ Object {
 
 exports[`AreaTaskSolver 2017-07-15-lev - P9 final result 1`] = `
 Object {
+  "aat_min_time_exceeded": true,
   "completed": true,
   "distance": 299195.36,
   "path": Array [
@@ -96,6 +98,7 @@ Object {
 
 exports[`AreaTaskSolver 2017-07-15-lev - SW 2017-07-15T12:00:00Z 1`] = `
 Object {
+  "aat_min_time_exceeded": false,
   "completed": false,
   "distance": 71060.548,
   "path": Array [
@@ -125,6 +128,7 @@ Object {
 
 exports[`AreaTaskSolver 2017-07-15-lev - SW final result 1`] = `
 Object {
+  "aat_min_time_exceeded": true,
   "completed": true,
   "distance": 227163.36,
   "path": Array [
@@ -172,6 +176,7 @@ Object {
 
 exports[`AreaTaskSolver 2017-07-15-lev - XN final result 1`] = `
 Object {
+  "aat_min_time_exceeded": false,
   "completed": false,
   "distance": 124525.47,
   "path": Array [
@@ -207,6 +212,7 @@ Object {
 
 exports[`AreaTaskSolver 2017-07-15-lev - ZG final result 1`] = `
 Object {
+  "aat_min_time_exceeded": false,
   "completed": false,
   "distance": 43099.650,
   "path": Array [

--- a/src/task/solver/area-task-solver.ts
+++ b/src/task/solver/area-task-solver.ts
@@ -207,10 +207,13 @@ export default class AreaTaskSolver {
         ? this.task.options.aatMinTime
         : time;
 
+      let aat_min_time_exceeded = time > this.task.options.aatMinTime;
+
       // calculate marking speed
       let speed = (distance / 1000) / (scoringTime / 3600);
 
       return {
+        aat_min_time_exceeded,
         completed,
         time,
         distance,
@@ -222,6 +225,7 @@ export default class AreaTaskSolver {
     // if we don't have data yet we can't return anything useful
     if (!this.bestSolution) {
       return {
+        aat_min_time_exceeded: false,
         completed: false,
         time: undefined,
         distance: undefined,
@@ -240,10 +244,13 @@ export default class AreaTaskSolver {
     // calculate current marking time
     let time = (this._lastFix!.time - path[0].time) / 1000;
 
+    let aat_min_time_exceeded = time > this.task.options.aatMinTime;
+
     // calculate current marking speed
     let speed = (distance / 1000) / (time / 3600);
 
     return {
+      aat_min_time_exceeded,
       completed,
       time,
       distance,


### PR DESCRIPTION
- AAT: Show min_time_exceeded flag in the ranking
  Example: (display speed `DSpeed` and marking speed `MSpeed` shown separately in this image (this branch only shows the marking speed in the end)
  ![image](https://user-images.githubusercontent.com/10089607/59644256-7a8bf980-916c-11e9-820a-db379f16dadf.png)
Flights which didn't reach the AAT min time are flagged by a star in the time column.

- scoring: Use marking speed calculated by the task solver, fixes #84