### PR TITLE
Extract `JsonTask` interface

### DIFF
--- a/src/read-task.ts
+++ b/src/read-task.ts
@@ -1,37 +1,10 @@
 import fs = require('fs');
-import Point from './geo/point';
 import Task from './task/task';
-import {JsonTask, JsonTurnpoint, taskFromJson} from './task/task-from-json';
-import {read} from './xcsoar';
+import { taskFromJson} from './task/task-from-json';
+import {xmlToJson} from './xcsoar/xml-to-json';
 
 export function readTaskFromString(str: string): Task {
-  let task = read(str);
-
-  let points: JsonTurnpoint[] = task.points.map(point => {
-    let lonlat: Point = [
-      point.waypoint.location.longitude,
-      point.waypoint.location.latitude,
-    ];
-
-    if (point.observation_zone.type === 'Cylinder') {
-      return { type: 'Cylinder', lonlat, radius: point.observation_zone.radius! };
-    }
-
-    if (point.observation_zone.type === 'Line') {
-      return { type: 'Line', lonlat, length: point.observation_zone.length! };
-    }
-
-    if (point.observation_zone.type === 'Keyhole') {
-      return { type: 'Keyhole', lonlat };
-    }
-
-    throw new Error(`Unknown zone type: ${point.observation_zone.type}`);
-  });
-
-  let json: JsonTask = task.type === 'AAT'
-    ? { type: 'AAT', minTime: task.aat_min_time || 0, points }
-    : { type: 'Racing', points };
-
+  let json = xmlToJson(str);
   return taskFromJson(json);
 }
 

--- a/src/read-task.ts
+++ b/src/read-task.ts
@@ -1,66 +1,41 @@
-import bearing from '@turf/bearing';
 import fs = require('fs');
-
 import Point from './geo/point';
-import {Cylinder, Keyhole, Line} from './task/shapes';
 import Task from './task/task';
-import {Turnpoint} from './turnpoint';
-import {fraction} from './utils/angles';
-import {read, XCSoarLocation} from './xcsoar';
+import {JsonTask, JsonTurnpoint, taskFromJson} from './task/task-from-json';
+import {read} from './xcsoar';
 
 export function readTaskFromString(str: string): Task {
   let task = read(str);
 
-  let points = task.points.map((point, i) => {
-    let location = convertLocation(point.waypoint.location);
+  let points: JsonTurnpoint[] = task.points.map(point => {
+    let lonlat: Point = [
+      point.waypoint.location.longitude,
+      point.waypoint.location.latitude,
+    ];
 
     if (point.observation_zone.type === 'Cylinder') {
-      return new Cylinder(location, point.observation_zone.radius!);
-    }
-
-    let direction;
-    if (i === 0) {
-      let locNext = convertLocation(task.points[i + 1].waypoint.location);
-      direction = bearing(location, locNext);
-
-    } else if (i === task.points.length - 1) {
-      let locPrev = convertLocation(task.points[i - 1].waypoint.location);
-      direction = bearing(locPrev, location);
-
-    } else {
-      let locPrev = convertLocation(task.points[i - 1].waypoint.location);
-      let locNext = convertLocation(task.points[i + 1].waypoint.location);
-
-      let bearingtoPrev = bearing(location, locPrev);
-      let bearingToNext = bearing(location, locNext);
-
-      let bisector = fraction(bearingtoPrev, bearingToNext);
-
-      direction = bisector - 90;
+      return { type: 'Cylinder', lonlat, radius: point.observation_zone.radius! };
     }
 
     if (point.observation_zone.type === 'Line') {
-      return new Line(location, point.observation_zone.length!, direction);
+      return { type: 'Line', lonlat, length: point.observation_zone.length! };
     }
 
     if (point.observation_zone.type === 'Keyhole') {
-      return new Keyhole(location, direction - 90);
+      return { type: 'Keyhole', lonlat };
     }
 
     throw new Error(`Unknown zone type: ${point.observation_zone.type}`);
-  }).map(oz => new Turnpoint(oz));
-
-  return new Task(points, {
-    isAAT: task.type === 'AAT',
-    aatMinTime: task.aat_min_time || 0,
   });
+
+  let json: JsonTask = task.type === 'AAT'
+    ? { type: 'AAT', minTime: task.aat_min_time || 0, points }
+    : { type: 'Racing', points };
+
+  return taskFromJson(json);
 }
 
 export function readTask(path: string): Task {
   let file = fs.readFileSync(path, 'utf8');
   return readTaskFromString(file);
-}
-
-function convertLocation(loc: XCSoarLocation): Point {
-  return [loc.longitude, loc.latitude];
 }

--- a/src/task/task-from-json.ts
+++ b/src/task/task-from-json.ts
@@ -1,0 +1,88 @@
+import bearing from '@turf/bearing';
+
+import {Turnpoint} from '../turnpoint';
+import {fraction} from '../utils/angles';
+import {Cylinder, Keyhole, Line, Sector} from './shapes';
+import Task from './task';
+
+export type JsonTask = JsonAreaTask | JsonRacingTask;
+export type JsonTurnpoint = JsonCylinder | JsonLine | JsonKeyhole | JsonSector;
+
+export interface JsonRacingTask {
+  type: 'Racing';
+  points: JsonTurnpoint[];
+}
+
+export interface JsonAreaTask {
+  type: 'AAT';
+  minTime: number;
+  points: JsonTurnpoint[];
+}
+
+export interface JsonCylinder {
+  type: 'Cylinder';
+  lonlat: [number, number];
+  radius: number;
+}
+
+export interface JsonLine {
+  type: 'Line';
+  lonlat: [number, number];
+  length: number;
+}
+
+export interface JsonSector {
+  type: 'Sector';
+  lonlat: [number, number];
+}
+
+export interface JsonKeyhole {
+  type: 'Keyhole';
+  lonlat: [number, number];
+}
+
+export function taskFromJson(input: JsonTask): Task {
+  let points = input.points.map((point, i) => {
+    let location = point.lonlat;
+
+    if (point.type === 'Cylinder') {
+      return new Cylinder(location, point.radius);
+    }
+
+    let direction;
+    if (i === 0) {
+      let locNext = input.points[i + 1].lonlat;
+      direction = bearing(location, locNext);
+
+    } else if (i === input.points.length - 1) {
+      let locPrev = input.points[i - 1].lonlat;
+      direction = bearing(locPrev, location);
+
+    } else {
+      let locPrev = input.points[i - 1].lonlat;
+      let locNext = input.points[i + 1].lonlat;
+
+      let bearingtoPrev = bearing(location, locPrev);
+      let bearingToNext = bearing(location, locNext);
+
+      let bisector = fraction(bearingtoPrev, bearingToNext);
+
+      direction = bisector - 90;
+    }
+
+    if (point.type === 'Line') {
+      return new Line(location, point.length, direction);
+    }
+
+    if (point.type === 'Keyhole') {
+      return new Keyhole(location, direction - 90);
+    }
+
+    throw new Error(`Unknown zone type: ${point.type}`);
+  }).map(oz => new Turnpoint(oz));
+
+  return new Task(points, {
+    isAAT: input.type === 'AAT',
+    aatMinTime: input.type === 'AAT' ? input.minTime : 0,
+  });
+}

--- a/src/xcsoar/xml-to-json.ts
+++ b/src/xcsoar/xml-to-json.ts
@@ -1,0 +1,32 @@
+import Point from '../geo/point';
+import {JsonTask, JsonTurnpoint} from '../task/task-from-json';
+import {read} from './index';
+
+export function xmlToJson(str: string): JsonTask {
+  let task = read(str);
+
+  let points: JsonTurnpoint[] = task.points.map(point => {
+    let lonlat: Point = [
+      point.waypoint.location.longitude,
+      point.waypoint.location.latitude,
+    ];
+
+    if (point.observation_zone.type === 'Cylinder') {
+      return { type: 'Cylinder', lonlat, radius: point.observation_zone.radius! };
+    }
+
+    if (point.observation_zone.type === 'Line') {
+      return { type: 'Line', lonlat, length: point.observation_zone.length! };
+    }
+
+    if (point.observation_zone.type === 'Keyhole') {
+      return { type: 'Keyhole', lonlat };
+    }
+
+    throw new Error(`Unknown zone type: ${point.observation_zone.type}`);
+  });
+
+  return task.type === 'AAT'
+    ? { type: 'AAT', minTime: task.aat_min_time || 0, points }
+    : { type: 'Racing', points };
+}


### PR DESCRIPTION
This PR extracts a `JsonTask` interface as an intermediate step between XCSoar XML task and the `Task` class. This intermediate representation can be serialized as JSON, which means it's easy to share the necessary task data with e.g. a WebWorker.